### PR TITLE
Add styles for collapsible/expandable container.

### DIFF
--- a/css/styles.min.css
+++ b/css/styles.min.css
@@ -27,3 +27,23 @@ button {
     padding: 10px;    
 }
 
+/*
+ * Use .list-container with a <details> tag, containing <summary> and <ul> as children.
+ */
+.list-container summary {
+  background: #eee;
+  cursor: pointer;
+  padding: .5rem 1rem;
+}
+
+.list-container summary:hover {
+  background: #ddd;
+}
+
+.list-container summary::-webkit-details-marker {
+  opacity: .5;
+}
+
+.list-container ul {
+  margin-top: .5rem;
+}


### PR DESCRIPTION
- [x] Add DOM transformer that wraps `<ul>`, `<nav>`, etc. in `<details>` as described below.
- [x] Add styles to improve the UX of the lists.

Actual functionality originates from the combination of HTML tags, not from the styles. It's generally applicable to any HTML element by wrapping it in the following way:

```html
<details>
    <summary>Click to Expand List</summary>

    <!-- The element to wrap. Can be anything. -->
    <ul>...</ul>
</details>
```